### PR TITLE
Add git installation instructions

### DIFF
--- a/guides/install-console-application.md
+++ b/guides/install-console-application.md
@@ -30,7 +30,7 @@ and follow the instructions.
 # Install Git for Desktop
 
 After Git installation above is complete, we recommend to use Git for Desktop.
-Fortunately, Git for Desktop is available for MoJ staff via Self serve.
+Fortunately, Git for Desktop is available for MoJ staff via the Self Service app.
 
 Alternatively, you can Download Git for desktop https://desktop.github.com/
 Unzip, double click the installer and follow the instructions there.

--- a/guides/install-console-application.md
+++ b/guides/install-console-application.md
@@ -1,6 +1,6 @@
 ---
 category: Using Form Builder
-expires: 2020-03-31
+expires: 2020-09-30
 ---
 
 # Installing Git

--- a/guides/install-console-application.md
+++ b/guides/install-console-application.md
@@ -2,22 +2,46 @@
 category: Using Form Builder
 expires: 2020-03-31
 ---
- 
+
+# Installing Git
+
+Git is a dependency of the Editor. Below is shown two ways to install Git.
+
+## Option 1: XCode
+
+Apple ships a binary package of Git with XCode.
+
+Open your terminal app (Command + Space then type Terminal + Enter)
+Type the following:
+
+    ```
+      xcode-select --install
+    ```
+
+Select "Yes" to install Git and wait until it finishes.
+
+## Option 2: Binary installer
+
+Tim Harper provides an installer for Git.
+You can download [here](https://sourceforge.net/projects/git-osx-installer/).
+After download, open the *.dmg file and double click the *.pkg file
+and follow the instructions.
+
 # Installing the Console
- 
+
 Form Builder Editor Console is an Electron app for users to run [Form Builder Editor](https://github.com/ministryofjustice/fb-editor-node) locally.
- 
+
 ### Installation
 Follow the instructions in the [GitHub repo](https://github.com/ministryofjustice/fb-editor-console-electron#fb-editor-console-electron).
- 
+
 ### Settings
 + GitHub user details
    - Name - Your name
    - Email address - Email address for you github account
    - Username - github username
- 
+
 + GitHub personal access token
    - Follow GitHub guidance to get your personal token (select scopes - check repo)
    - Password - this is password is only to encyrpt the personal token
-  
+
 Happy Form Building

--- a/guides/install-console-application.md
+++ b/guides/install-console-application.md
@@ -27,6 +27,14 @@ You can download [here](https://sourceforge.net/projects/git-osx-installer/).
 After download, open the *.dmg file and double click the *.pkg file
 and follow the instructions.
 
+# Install Git for Desktop
+
+After Git installation above is complete, we recommend to use Git for Desktop.
+Fortunately, Git for Desktop is available for MoJ staff via Self serve.
+
+Alternatively, you can Download Git for desktop https://desktop.github.com/
+Unzip, double click the installer and follow the instructions there.
+
 # Installing the Console
 
 Form Builder Editor Console is an Electron app for users to run [Form Builder Editor](https://github.com/ministryofjustice/fb-editor-node) locally.


### PR DESCRIPTION
Add git installation instruction in case users doesn't have Git installed.

The work that references this documentation can be seem here: https://github.com/ministryofjustice/fb-editor-console-electron/pull/306