### PR TITLE
Disaster Recovery Documentation for DB snapshots

### DIFF
--- a/troubleshooting/disaster_recovery.md
+++ b/troubleshooting/disaster_recovery.md
@@ -15,33 +15,7 @@ If any environment needs to be rebuilt from scratch it should simply the case of
 
 All Form Builder applications have deployment pipelines in CircleCI. As long as the infrastructure is in place it should simply be the case to run the deployment jobs and the app containers will deploy out to the required environments.
 
-If for some reason the CircleCI jobs have been lost then each app will need to be readded and the required environment variables set. These will differ for each application but these are the basic set which all apps require:
-
-- AWS_ACCESS_KEY_ID
-
-- AWS_SECRET_ACCESS_KEY
-
-- AWS_ECR_ACCOUNT_URL - repo which holds the form builder application images
-
-- CIRCLE_TOKEN - required for triggering acceptance tests via curl. Not every job will want to trigger the acceptance tests
-
-- ENCODED_GIT_CRYPT_KEY - used for decrypting secrets for the application via git-crypt
-
-- KUBE_CERTIFICATE_AUTHORITY
-
-- KUBE_CLUSTER
-
-- KUBE_SERVER
-
-- KUBE_TOKEN - used to authenticate with the kubernetes cluster
-
-- KUBE_TOKEN_TEST_DEV
-
-- KUBE_TOKEN_TEST_PRODUCTION
-
-- KUBE_TOKEN_LIVE_DEV
-
-- KUBE_TOKEN_LIVE_PRODUCTION
+If for some reason the CircleCI jobs have been lost then each app will need to be readded and the required environment variables set. These will differ for each application. See the [fb-deploy](https://github.com/ministryofjustice/fb-deploy) repo for more instructions.
 
 ### Databases
 

--- a/troubleshooting/disaster_recovery.md
+++ b/troubleshooting/disaster_recovery.md
@@ -46,3 +46,15 @@ If for some reason the CircleCI jobs have been lost then each app will need to b
 ### Databases
 
 Users main submission data is held encrypted in RDS Postgres instances which have regular snapshot backups. We would need to ask the Cloud Platform team to restore these for us if required.
+
+Currently the developers on the MoJ Online team are unable to access the AWS accounts that hold any of our databases and their snapshots. This means that we would need Cloud Platform's assistance to restore any snapshot. If a snapshot recovery is required get in contact with Cloud Platform and follow [these instructions](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/rds-snapshots.html#restoring-live-services-from-a-rds-db-snapshot).
+
+Currently the RDS instances we have are:
+
+- Datastore
+- HMCTS Adapater
+- Metadata API
+- Publisher
+- Submitter
+
+We also have a Redis Elasticache instance connected to the Service Token Cache, but if this goes down then all the public keys will simply be retrieved from Kubernetes upon the next request to the cache.


### PR DESCRIPTION
## Additional documentation for disaster recovery of DBs

We can't actually recover them ourselves so add a bit of documentation
on who to contact.

## Remove references to deployment pipeline environment variables …

The fb-deploy repo now talks about these in greater detail.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>